### PR TITLE
Shadowed players drop their inventory on re-log [FIX]

### DIFF
--- a/src/main/java/essentialaddons/mixins/reloadFakePlayers/EntityPlayerMPFakeMixin.java
+++ b/src/main/java/essentialaddons/mixins/reloadFakePlayers/EntityPlayerMPFakeMixin.java
@@ -16,6 +16,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
 import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.World;
 import net.minecraft.world.dimension.DimensionType;
@@ -38,7 +39,10 @@ public abstract class EntityPlayerMPFakeMixin extends ServerPlayerEntity impleme
 	@Inject(method = "kill(Lnet/minecraft/text/Text;)V", at = @At("HEAD"))
 	private void onPlayerKill(Text reason, CallbackInfo ci) {
 		ConfigFakePlayerData.INSTANCE.removeFakePlayer((EntityPlayerMPFake) (Object) this);
-		if(EssentialSettings.fakePlayerDropInventoryOnKill) this.dropInventory();
+		if(EssentialSettings.fakePlayerDropInventoryOnKill
+			&& !(reason instanceof TranslatableText TTreason
+				&& TTreason.getKey().equals("multiplayer.disconnect.duplicate_login")))
+			this.dropInventory();
 	}
 
 	@Override


### PR DESCRIPTION
When a player join the server while a bot with the same name is logged, the game will kill the bot.
With `fakePlayerDropInventoryOnKill` enabled, those bot will drop their inventory.

Added the exception in `fakePlayerDropInventoryOnKill` to not drop items if the reason ok the logout is a duplicate login. 