### PR TITLE
Make `carefulDrop` minecart mixins more compatible, remove `dropCartItem` rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ logs/
 *.ipr
 *.iws
 
+# eclipse
+*.launch
+
 # vscode
 
 .settings/

--- a/src/main/java/essentialaddons/EssentialSettings.java
+++ b/src/main/java/essentialaddons/EssentialSettings.java
@@ -290,13 +290,6 @@ public class EssentialSettings {
     public static String commandWorkbench = "false";
 
     @Rule(
-        desc = "Drops the whole minecraft item, back-ported from 1.19",
-        options = {"true", "false"},
-        category = {ESSENTIAL, SURVIVAL, FEATURE}
-    )
-    public static boolean dropCartItem = false;
-
-    @Rule(
         desc = "Allows your to edit a sign after its places by right clicking it while sneaking",
         options = {"true", "false"},
         category = {ESSENTIAL, EXPERIMENTAL, FEATURE}

--- a/src/main/java/essentialaddons/mixins/essentialCarefulDrop/AbstractMinecartEntityMixin.java
+++ b/src/main/java/essentialaddons/mixins/essentialCarefulDrop/AbstractMinecartEntityMixin.java
@@ -3,45 +3,24 @@ package essentialaddons.mixins.essentialCarefulDrop;
 import essentialaddons.EssentialSettings;
 import essentialaddons.EssentialUtils;
 import essentialaddons.utils.Subscription;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityType;
+import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.vehicle.AbstractMinecartEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(AbstractMinecartEntity.class)
-public abstract class AbstractMinecartEntityMixin extends Entity {
-	public AbstractMinecartEntityMixin(EntityType<?> type, World world) {
-		super(type, world);
-	}
-
-	@Shadow public abstract ItemStack getPickBlockStack();
-
-	@Inject(method = "dropItems", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;<init>(Lnet/minecraft/item/ItemConvertible;)V", shift = At.Shift.BEFORE), cancellable = true)
-	private void onDropItems(DamageSource damageSource, CallbackInfo ci) {
-		ci.cancel();
-
-		ItemStack itemStack = EssentialSettings.dropCartItem ? this.getPickBlockStack() : new ItemStack(Items.MINECART);
-		if (itemStack == null) {
-			return;
-		}
-
-		if (this.hasCustomName()) {
-			itemStack.setCustomName(this.getCustomName());
-		}
+public abstract class AbstractMinecartEntityMixin {
+	@Redirect(method = "dropItems", at = @At(value = "INVOKE", target = "net/minecraft/entity/vehicle/AbstractMinecartEntity.dropStack(Lnet/minecraft/item/ItemStack;)Lnet/minecraft/entity/ItemEntity;"))
+	private ItemEntity onDropItems(AbstractMinecartEntity e, ItemStack stack, DamageSource damageSource) {
 		if (EssentialSettings.essentialCarefulDrop && damageSource.getSource() instanceof ServerPlayerEntity player && (player.isInSneakingPose() || Subscription.ALWAYS_CAREFUL.hasPlayer(player))) {
-			if (Subscription.ESSENTIAL_CAREFUL_DROP.hasPlayer(player) && EssentialUtils.placeItemInInventory(player, itemStack)) {
-				return;
+			if (Subscription.ESSENTIAL_CAREFUL_DROP.hasPlayer(player) && EssentialUtils.placeItemInInventory(player, stack)) {
+				return null;
 			}
 		}
-		this.dropStack(itemStack);
+		return e.dropStack(stack);
 	}
 }

--- a/src/main/java/essentialaddons/mixins/essentialCarefulDrop/ChestMinecartEntityMixin.java
+++ b/src/main/java/essentialaddons/mixins/essentialCarefulDrop/ChestMinecartEntityMixin.java
@@ -3,36 +3,24 @@ package essentialaddons.mixins.essentialCarefulDrop;
 import essentialaddons.EssentialSettings;
 import essentialaddons.EssentialUtils;
 import essentialaddons.utils.Subscription;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityType;
+import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.vehicle.ChestMinecartEntity;
-import net.minecraft.item.Items;
+import net.minecraft.item.ItemConvertible;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(ChestMinecartEntity.class)
-public abstract class ChestMinecartEntityMixin extends Entity {
-	public ChestMinecartEntityMixin(EntityType<?> type, World world) {
-		super(type, world);
-	}
-
-	@Inject(method = "dropItems", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/vehicle/ChestMinecartEntity;dropItem(Lnet/minecraft/item/ItemConvertible;)Lnet/minecraft/entity/ItemEntity;", shift = At.Shift.BEFORE), cancellable = true)
-	private void onDropStack(DamageSource damageSource, CallbackInfo ci) {
-		ci.cancel();
-		if (EssentialSettings.dropCartItem) {
-			return;
-		}
-
+public abstract class ChestMinecartEntityMixin { //TODO priorities
+	@Redirect(method = "dropItems", at = @At(value = "INVOKE", target = "net/minecraft/entity/vehicle/ChestMinecartEntity.dropItem(Lnet/minecraft/item/ItemConvertible;)Lnet/minecraft/entity/ItemEntity;"))
+	private ItemEntity onDropStack(ChestMinecartEntity e, ItemConvertible item, DamageSource damageSource) {
 		if (EssentialSettings.essentialCarefulDrop && damageSource.getSource() instanceof ServerPlayerEntity player && (player.isInSneakingPose() || Subscription.ALWAYS_CAREFUL.hasPlayer(player))) {
-			if (Subscription.ESSENTIAL_CAREFUL_DROP.hasPlayer(player) && EssentialUtils.placeItemInInventory(player, Items.CHEST.getDefaultStack())) {
-				return;
+			if (Subscription.ESSENTIAL_CAREFUL_DROP.hasPlayer(player) && EssentialUtils.placeItemInInventory(player, item.asItem().getDefaultStack())) {
+				return null;
 			}
 		}
-		this.dropItem(Items.CHEST);
+		return e.dropItem(item);
 	}
 }

--- a/src/main/java/essentialaddons/mixins/essentialCarefulDrop/FurnaceMinecartEntityMixin.java
+++ b/src/main/java/essentialaddons/mixins/essentialCarefulDrop/FurnaceMinecartEntityMixin.java
@@ -3,36 +3,24 @@ package essentialaddons.mixins.essentialCarefulDrop;
 import essentialaddons.EssentialSettings;
 import essentialaddons.EssentialUtils;
 import essentialaddons.utils.Subscription;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityType;
+import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.vehicle.FurnaceMinecartEntity;
-import net.minecraft.item.Items;
+import net.minecraft.item.ItemConvertible;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(FurnaceMinecartEntity.class)
-public abstract class FurnaceMinecartEntityMixin extends Entity {
-	public FurnaceMinecartEntityMixin(EntityType<?> type, World world) {
-		super(type, world);
-	}
-
-	@Inject(method = "dropItems", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/vehicle/FurnaceMinecartEntity;dropItem(Lnet/minecraft/item/ItemConvertible;)Lnet/minecraft/entity/ItemEntity;", shift = At.Shift.BEFORE), cancellable = true)
-	private void onDropStack(DamageSource damageSource, CallbackInfo ci) {
-		ci.cancel();
-		if (EssentialSettings.dropCartItem) {
-			return;
-		}
-
+public abstract class FurnaceMinecartEntityMixin {
+	@Redirect(method = "dropItems", at = @At(value = "INVOKE", target = "net/minecraft/entity/vehicle/FurnaceMinecartEntity.dropItem(Lnet/minecraft/item/ItemConvertible;)Lnet/minecraft/entity/ItemEntity;"))
+	private ItemEntity onDropStack(FurnaceMinecartEntity e, ItemConvertible item, DamageSource damageSource) {
 		if (EssentialSettings.essentialCarefulDrop && damageSource.getSource() instanceof ServerPlayerEntity player && (player.isInSneakingPose() || Subscription.ALWAYS_CAREFUL.hasPlayer(player))) {
-			if (Subscription.ESSENTIAL_CAREFUL_DROP.hasPlayer(player) && EssentialUtils.placeItemInInventory(player, Items.FURNACE.getDefaultStack())) {
-				return;
+			if (Subscription.ESSENTIAL_CAREFUL_DROP.hasPlayer(player) && EssentialUtils.placeItemInInventory(player, item.asItem().getDefaultStack())) {
+				return null;
 			}
 		}
-		this.dropItem(Items.FURNACE);
+		return e.dropItem(item);
 	}
 }

--- a/src/main/java/essentialaddons/mixins/essentialCarefulDrop/HopperMinecartEntityMixin.java
+++ b/src/main/java/essentialaddons/mixins/essentialCarefulDrop/HopperMinecartEntityMixin.java
@@ -3,36 +3,25 @@ package essentialaddons.mixins.essentialCarefulDrop;
 import essentialaddons.EssentialSettings;
 import essentialaddons.EssentialUtils;
 import essentialaddons.utils.Subscription;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityType;
+import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.vehicle.HopperMinecartEntity;
-import net.minecraft.item.Items;
+import net.minecraft.item.ItemConvertible;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(HopperMinecartEntity.class)
-public abstract class HopperMinecartEntityMixin extends Entity {
-	public HopperMinecartEntityMixin(EntityType<?> type, World world) {
-		super(type, world);
-	}
+public abstract class HopperMinecartEntityMixin {
 
-	@Inject(method = "dropItems", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/vehicle/HopperMinecartEntity;dropItem(Lnet/minecraft/item/ItemConvertible;)Lnet/minecraft/entity/ItemEntity;", shift = At.Shift.BEFORE), cancellable = true)
-	private void onDropStack(DamageSource damageSource, CallbackInfo ci) {
-		ci.cancel();
-		if (EssentialSettings.dropCartItem) {
-			return;
-		}
-
+	@Redirect(method = "dropItems", at = @At(value = "INVOKE", target = "net/minecraft/entity/vehicle/HopperMinecartEntity.dropItem(Lnet/minecraft/item/ItemConvertible;)Lnet/minecraft/entity/ItemEntity;"))
+	private ItemEntity onDropStack(HopperMinecartEntity e, ItemConvertible item, DamageSource damageSource) {
 		if (EssentialSettings.essentialCarefulDrop && damageSource.getSource() instanceof ServerPlayerEntity player && (player.isInSneakingPose() || Subscription.ALWAYS_CAREFUL.hasPlayer(player))) {
-			if (Subscription.ESSENTIAL_CAREFUL_DROP.hasPlayer(player) && EssentialUtils.placeItemInInventory(player, Items.HOPPER.getDefaultStack())) {
-				return;
+			if (Subscription.ESSENTIAL_CAREFUL_DROP.hasPlayer(player) && EssentialUtils.placeItemInInventory(player, item.asItem().getDefaultStack())) {
+				return null;
 			}
 		}
-		this.dropItem(Items.HOPPER);
+		return e.dropItem(item);
 	}
 }

--- a/src/main/java/essentialaddons/mixins/essentialCarefulDrop/TntMinecartMixin.java
+++ b/src/main/java/essentialaddons/mixins/essentialCarefulDrop/TntMinecartMixin.java
@@ -3,36 +3,24 @@ package essentialaddons.mixins.essentialCarefulDrop;
 import essentialaddons.EssentialSettings;
 import essentialaddons.EssentialUtils;
 import essentialaddons.utils.Subscription;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityType;
+import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.vehicle.TntMinecartEntity;
-import net.minecraft.item.Items;
+import net.minecraft.item.ItemConvertible;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(TntMinecartEntity.class)
-public abstract class TntMinecartMixin extends Entity {
-	public TntMinecartMixin(EntityType<?> type, World world) {
-		super(type, world);
-	}
-
-	@Inject(method = "dropItems", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/vehicle/TntMinecartEntity;dropItem(Lnet/minecraft/item/ItemConvertible;)Lnet/minecraft/entity/ItemEntity;", shift = At.Shift.BEFORE), cancellable = true)
-	private void onDropItems(DamageSource damageSource, CallbackInfo ci) {
-		ci.cancel();
-		if (EssentialSettings.dropCartItem) {
-			return;
-		}
-
+public abstract class TntMinecartMixin {
+	@Redirect(method = "dropItems", at = @At(value = "INVOKE", target = "net/minecraft/entity/vehicle/TntMinecartEntity.dropItem(Lnet/minecraft/item/ItemConvertible;)Lnet/minecraft/entity/ItemEntity;"))
+	private ItemEntity onDropStack(TntMinecartEntity e, ItemConvertible item, DamageSource damageSource) {
 		if (EssentialSettings.essentialCarefulDrop && damageSource.getSource() instanceof ServerPlayerEntity player && (player.isInSneakingPose() || Subscription.ALWAYS_CAREFUL.hasPlayer(player))) {
-			if (Subscription.ESSENTIAL_CAREFUL_DROP.hasPlayer(player) && EssentialUtils.placeItemInInventory(player, Items.TNT.getDefaultStack())) {
-				return;
+			if (Subscription.ESSENTIAL_CAREFUL_DROP.hasPlayer(player) && EssentialUtils.placeItemInInventory(player, item.asItem().getDefaultStack())) {
+				return null;
 			}
 		}
-		this.dropItem(Items.TNT);
+		return e.dropItem(item);
 	}
 }


### PR DESCRIPTION
This PR simplifies the mixins around minecarts for careful drop and makes them more compatible by only redirecting what's strictly necessary and getting the items from the existing code instead of duplicating vanilla code, meaning other mods can change them and EssentialAddons get the updated ones.

Also removes the `dropCartItem` rule from the comments in #39, feel free to close if you don't want to do that.

This makes the mod compatible with DropFullCarts, both with and without careful drop enabled (therefore fixes altrisi/DropFullCarts#2).

And adds Eclipse `.launch` files to `.gitignore`.

I didn't add #39 in a closes clause given there's still other Inject & Cancels in the mod which IMO aren't a good way to do stuff, but I don't know of any other current issues caused by them.