### PR TITLE
Fix NPE if server is null

### DIFF
--- a/src/main/java/essentialaddons/EssentialUtils.java
+++ b/src/main/java/essentialaddons/EssentialUtils.java
@@ -114,9 +114,13 @@ public class EssentialUtils {
         return false;
     }
 
-    public static Path getSavePath() {
-        return server.getSavePath(WorldSavePath.ROOT);
-    }
+	public static Path getSavePath() {
+		if (server == null){
+			FabricLoader fabricLoader = FabricLoader.getInstance();
+			return fabricLoader.getConfigDir();
+		}
+		return server.getSavePath(WorldSavePath.ROOT);
+	}
 
     public static Path getConfigPath() {
         FabricLoader fabricLoader = FabricLoader.getInstance();


### PR DESCRIPTION
Some modded instance can leave server as null at start up. 
This just offers safe fallback if server is somehow null at runtime.